### PR TITLE
initial changes to replace monocle with johanvos-headless javafx branch

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,7 @@ tasks.withType(AbstractArchiveTask) {
 }
 
 javafx {
-    version = "18"
+    sdk = "/home/scy/git/jfx-sandbox/build/sdk"
     modules = [ 'javafx.controls', 'javafx.fxml', 'javafx.swing', 'javafx.graphics' ]
 }
 
@@ -198,7 +198,7 @@ application {
                                       "--add-opens=javafx.graphics/com.sun.glass.ui.mac=centerdevice.nsmenufx"]
     }
     if(headless) {
-        applicationDefaultJvmArgs += ["-Dglass.platform=Monocle", "-Dmonocle.platform=Headless", "-Dprism.order=sw"]
+        applicationDefaultJvmArgs += ["-Dglass.platform=Headless", "-Dprism.order=sw"]
     }
 }
 
@@ -262,7 +262,7 @@ jlink {
             jvmArgs += ["-Dprism.lcdtext=false", "--add-opens=javafx.graphics/com.sun.glass.ui.mac=com.sparrowwallet.merged.module"]
         }
         if(headless) {
-            jvmArgs += ["-Dglass.platform=Monocle", "-Dmonocle.platform=Headless", "-Dprism.order=sw"]
+            jvmArgs += ["-Dglass.platform=Headless", "-Dprism.order=sw"]
         }
     }
     addExtraDependencies("javafx")

--- a/src/main/java/com/sparrowwallet/sparrow/Interface.java
+++ b/src/main/java/com/sparrowwallet/sparrow/Interface.java
@@ -8,13 +8,13 @@ public enum Interface {
     public static Interface get() {
         if(currentInterface == null) {
             boolean headless = java.awt.GraphicsEnvironment.isHeadless();
-            boolean monocle = "Monocle".equalsIgnoreCase(System.getProperty("glass.platform"));
+            boolean glassHeadless = "Headless".equalsIgnoreCase(System.getProperty("glass.platform"));
 
-            if(headless || monocle) {
+            if(headless || glassHeadless) {
                 currentInterface = TERMINAL;
 
-                if(headless && !monocle) {
-                    throw new UnsupportedOperationException("Headless environment detected but Monocle platform not found");
+                if(headless && !glassHeadless) {
+                    throw new UnsupportedOperationException("Headless environment detected but Headless platform not found");
                 }
             } else {
                 currentInterface = DESKTOP;


### PR DESCRIPTION
## Summary by Sourcery

Standardize headless mode configuration by replacing Monocle references with a generic "Headless" glass.platform property and update JavaFX build settings to use a local SDK path.

Enhancements:
- Refactor headless detection in Interface.java to use a "Headless" glass.platform property and update exception messaging.
- Remove obsolete -Dmonocle.platform JVM argument and adjust headless JVM args in both application and jlink Gradle tasks.
- Change JavaFX plugin configuration to point to a local SDK path instead of a version string.